### PR TITLE
Add designed whitepaper reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 
 | Need | Start here |
 | --- | --- |
-| Read the full public whitepaper | [Full Whitepaper](FULL_WHITEPAPER.md) |
+| Read the designed whitepaper reader | [Designed Whitepaper Reader](whitepaper/README.md) |
+| Read the full public whitepaper archive | [Full Whitepaper](FULL_WHITEPAPER.md) |
 | Run the public demo loop | [Quickstart](QUICKSTART.md) |
 | Understand contracts | [Contract Spec](CONTRACT-SPEC.md) |
 | Understand scoring | [Grading Rubric](GRADING-RUBRIC.md) |
@@ -72,7 +73,8 @@ This is an early public specification with runnable reference material.
 
 | Public artifact | What it does | What it is not |
 | --- | --- | --- |
-| [Full Whitepaper](FULL_WHITEPAPER.md) | Defines enforcement-first AI operations for hospitality | Not the production runtime |
+| [Designed Whitepaper Reader](whitepaper/README.md) | Presents the whitepaper as a visual multi-part reader | Not the production runtime |
+| [Full Whitepaper](FULL_WHITEPAPER.md) | Preserves the complete long-form paper in one file | Not the production runtime |
 | [Mock loop](reference/end_to_end_mock_loop.py) | Shows contract, mock execution, dummy grading, decision, feedback, and iteration | Not the production runtime |
 | [Validators](validators) | Check public contract and grading result shape | Not the production grader |
 | [JSON Schemas](schemas) | Define public JSON shapes | Not the private schema system |
@@ -80,7 +82,7 @@ This is an early public specification with runnable reference material.
 | [Reliability notes](GRADER_RELIABILITY.md) | Explain public grader trust questions | Not private scoring implementation |
 
 > [!TIP]
-> Start with `python reference/end_to_end_mock_loop.py` if you want to see the loop move instead of only reading about it.
+> Start with `whitepaper/README.md` for the designed reader, or `python reference/end_to_end_mock_loop.py` if you want to see the loop move instead of only reading about it.
 
 ## What Stays Closed
 

--- a/whitepaper/01-foundation.md
+++ b/whitepaper/01-foundation.md
@@ -1,0 +1,75 @@
+# 01 — Foundation
+
+> [!IMPORTANT]
+> HaleES starts from a simple operating belief: a useful answer is not the same thing as a trusted action.
+
+## The Problem
+
+Most AI systems are designed around generation.
+
+They answer questions. They summarize information. They suggest next steps. They create schedules, workflows, messages, images, and recommendations.
+
+That is useful, but it is not enough for real operations.
+
+| AI can generate | Hospitality must still ask |
+| --- | --- |
+| A schedule | Is it allowed to be published? |
+| A labor cut | Is it safe, legal, and staffed correctly? |
+| A guest response | Who approved it and what policy applies? |
+| A coaching note | Is this a coaching moment or a protected HR issue? |
+| A menu special | Is inventory, vendor status, and offer language verified? |
+
+A wrong answer can waste time. A wrong action can damage trust, cost money, violate policy, create liability, or undermine a manager's authority.
+
+## Central Claim
+
+> [!WARNING]
+> The next phase of AI in business will not be defined only by better models. It will be defined by better control systems around those models.
+
+AI should not be trusted to act simply because it sounds useful. It must earn permission through authority checks, task contracts, grading, auditability, human review, and consequence feedback.
+
+This is the difference between answer generation and trusted action.
+
+## Why Hospitality
+
+Hospitality is an ideal proving ground for enforcement-first AI because it is operationally dense.
+
+A restaurant or hotel is not just a place where tasks happen. It is a live environment where labor, demand, service timing, guest emotion, compliance, inventory, cleanliness, training, communication, and leadership all collide in real time.
+
+| Hospitality decision | Why it is not only a data question |
+| --- | --- |
+| Who should be cut first? | Labor, fairness, coverage, role skill, and upcoming demand all matter |
+| Who can cover a call off? | Availability, overtime, eligibility, role permission, and communication policy matter |
+| Is labor safe? | Service promise, station coverage, and guest experience matter |
+| Is a complaint isolated? | Pattern detection, guest recovery, privacy, and manager judgment matter |
+| Should a schedule be published? | Authority, availability, staffing ratios, and approval requirements matter |
+
+These are not only data questions. They are authority questions.
+
+## Governed Execution
+
+A standard AI workflow often looks like this:
+
+```text
+Prompt -> Model -> Output
+```
+
+HaleES uses a stricter pattern:
+
+```text
+Request -> Contract -> Authority Check -> Policy Check -> Ground Truth Verification -> Execution Within Scope -> Grading -> Acceptance Gate -> Human Approval If Required -> Audit Trail -> Outcome Review
+```
+
+> [!NOTE]
+> The AI can assist, recommend, prepare, and execute inside approved limits. It does not automatically inherit permission.
+
+## Foundation Principle
+
+| Principle | Meaning |
+| --- | --- |
+| Knowledge is not authority | Knowing what should happen does not mean having permission to do it |
+| Generation is not acceptance | Output must be evaluated before it becomes operational |
+| Confidence is not proof | A confident model can still be wrong, incomplete, stale, or unauthorized |
+| Scores are not decisions | A score informs the gate; the gate determines whether action can proceed |
+
+[Back to reader](README.md) · [Next: Governance](02-governance.md)

--- a/whitepaper/02-governance.md
+++ b/whitepaper/02-governance.md
@@ -1,0 +1,91 @@
+# 02 — Governance
+
+> [!IMPORTANT]
+> Authority is not a feature added later. It must be part of the foundation.
+
+## Authority Before Execution
+
+In hospitality operations, different people have different rights.
+
+| Role | Typical authority boundary |
+| --- | --- |
+| Team member | May request, report, and acknowledge |
+| Shift lead | May adjust limited floor operations |
+| Manager | May approve operational changes inside scope |
+| General manager | May approve store-level decisions |
+| Owner/operator | May define policy, budget, integrations, and automation limits |
+
+A system that can generate a schedule does not automatically have the right to publish that schedule.
+
+A system that can identify labor waste does not automatically have the right to cut employees.
+
+A system that can draft a message does not automatically have the right to send it.
+
+| Capability | Permission question |
+| --- | --- |
+| Generate a schedule | Can it publish the schedule? |
+| Detect labor waste | Can it cut labor? |
+| Draft a message | Can it send the message? |
+| Identify performance concern | Can it create documentation? |
+| Recommend a refund | Can it issue the refund? |
+
+## Authority Does Not Override Core Policy
+
+> [!WARNING]
+> A high-authority user can still make a request the system must refuse.
+
+HaleES separates authority from permission.
+
+A general manager may have authority over a store. That does not mean the general manager can override labor law, safety policy, wage rules, minor restrictions, privacy rules, refund controls, security controls, or required staffing ratios.
+
+This requires a constitutional layer.
+
+| Constitutional boundary | Public example |
+| --- | --- |
+| Labor law | Minor restrictions, overtime, wage rules |
+| Food safety | Handling, storage, cleanliness, temperature requirements |
+| Privacy | Employee, guest, and business data rules |
+| Financial controls | Refund limits, payroll changes, vendor exposure |
+| Security controls | Permission grants, identity, integration access |
+| Service model constraints | Required staffing ratios, brand standards, safety coverage |
+
+Authority gives a user the right to request action.
+
+Policy decides whether that action is allowed.
+
+## Contracts Before Tasks
+
+A task should not be handed to an AI as a vague prompt and accepted because the response sounds good.
+
+In this architecture, work is framed as a contract.
+
+| Contract field | Purpose |
+| --- | --- |
+| Objective | Defines the work |
+| Operating context | Defines the environment |
+| Required inputs | Prevents missing context |
+| Constraints | Makes policy enforceable |
+| Role boundaries | Defines who can approve or act |
+| Acceptance criteria | Defines what passing means |
+| Risk level | Determines review and escalation |
+| Allowed tools | Prevents unauthorized execution |
+| Expected output | Prevents vague deliverables |
+| Grading rules | Defines evaluation |
+| Iteration limits | Prevents drift and endless retry |
+| Audit requirements | Preserves traceability |
+
+> [!TIP]
+> A schedule contract should not say “make a better schedule.” It should define the store, date, approved employees, availability, labor targets, role coverage, minor restrictions, overtime limits, staffing ratios, and approval requirements.
+
+## Governance Outcome
+
+| Input | Gate |
+| --- | --- |
+| User intent | Is the request clear? |
+| User role | Does this person have authority? |
+| Policy | Is the action allowed? |
+| Contract | Is the work bounded? |
+| Risk level | Is human approval required? |
+| Audit requirement | Can the decision be reconstructed later? |
+
+[Back to reader](README.md) · [Previous: Foundation](01-foundation.md) · [Next: Constraints](03-constraints.md)

--- a/whitepaper/03-constraints.md
+++ b/whitepaper/03-constraints.md
@@ -1,0 +1,104 @@
+# 03 — Constraints
+
+> [!IMPORTANT]
+> Constraints are how HaleES turns identity, policy, and service promise into operational control.
+
+## Staffing Ratios As Hard Constraints
+
+Some operating rules should be treated as identity-level constraints.
+
+A luxury property, a budget property, a quick service restaurant, a full service restaurant, and a high volume bar do not operate with the same staffing logic.
+
+Their ratios are not just numbers. They define the service promise.
+
+| Business identity | Service promise | Constraint meaning |
+| --- | --- | --- |
+| Luxury property | High-touch service | Lower guest-to-staff tolerance |
+| Budget property | Efficient support | Higher guest-to-staff tolerance may be acceptable |
+| Quick service restaurant | Speed and station coverage | Rush windows require role coverage |
+| Full service restaurant | Table experience | Server load and support roles matter |
+| High volume bar | Throughput and safety | Demand spikes require support roles |
+
+A plan can save money and still be wrong.
+
+A labor recommendation is only valid if it protects the service model it is operating inside.
+
+## Public Staffing Ratio Constants Pattern
+
+```text
+OPERATING_IDENTITY -> SERVICE_PROMISE -> STAFFING_RATIO_CONSTANT -> CONTRACT_CONSTRAINT -> ACCEPTANCE_GATE
+```
+
+| Public example identity | Example constant | Constraint posture |
+| --- | --- | --- |
+| Luxury service desk | `MAX_ACTIVE_GUESTS_PER_DESK_AGENT = 8` | Hard when tied to brand promise, safety, or service standard |
+| Budget service desk | `MAX_ACTIVE_GUESTS_PER_DESK_AGENT = 30` | Soft or configurable by property policy |
+| Quick service rush line | `MIN_STATION_COVERAGE_REQUIRED = true` | Hard during active rush windows |
+| Full service dining room | `MAX_TABLES_PER_SERVER = policy_defined` | Configurable by concept and service style |
+| High volume bar | `MIN_BAR_SUPPORT_ROLE_REQUIRED = true` | Hard or elevated during demand spikes |
+
+> [!NOTE]
+> These values are public examples, not production defaults.
+
+<details>
+<summary><strong>View identity-to-constraint diagram</strong></summary>
+
+```mermaid
+flowchart TD
+    A[Operating Identity] --> B[Service Promise]
+    B --> C[Staffing Ratio Constant]
+    C --> D[Task Contract Constraint]
+    D --> E[Grading Penalty Or Failure]
+    E --> F{Acceptance Gate}
+    F -->|Compliant| G[May Proceed Within Scope]
+    F -->|Violation| H[Block Escalate Or Require Approved Exception]
+```
+
+</details>
+
+## Hard vs Soft Constraints
+
+| Constraint type | Behavior |
+| --- | --- |
+| Hard constraint | Fails the binary acceptance gate when violated |
+| Soft constraint | Lowers confidence, adds warning, or requires human review |
+| Non-overridable policy | Cannot be bypassed by normal approval |
+| Emergency exception | Requires reason, identity confirmation, elevated approval where possible, and audit record |
+
+When a staffing ratio is classified as hard, a recommendation that violates the ratio should fail the binary acceptance gate even if the global score is otherwise strong.
+
+When a staffing ratio is tied to law, safety, minors, wage rules, or non-overridable policy, it should not be bypassed by normal human approval.
+
+## External Ground Truth
+
+Hospitality depends on outside systems.
+
+| Signal | Why it matters |
+| --- | --- |
+| Inventory | Prevents stale menu recommendations |
+| Vendor status | Prevents unavailable specials |
+| Weather | Adjusts demand and staffing expectations |
+| Local events | Explains demand spikes |
+| POS data | Grounds sales, labor, and item movement |
+| Reservations | Grounds guest volume and service load |
+| Delivery platforms | Reveals off-premise demand pressure |
+
+A recommendation built on stale or missing external data should not be treated the same as a recommendation built on verified ground truth.
+
+## Grading Before Acceptance
+
+HaleES uses grading as a core architectural primitive.
+
+| Layer | Purpose |
+| --- | --- |
+| 0 to 100 evaluation | Measures quality, completeness, usefulness, and constraint adherence |
+| 0 or 1 acceptance | Decides whether the output may proceed |
+| Feedback | Tells the system what must change |
+| Escalation | Moves unsafe or incomplete work to review |
+
+> [!WARNING]
+> A result can be useful and still not be allowed to act.
+
+For example, a schedule recommendation might look strong overall but fail because one employee is scheduled outside availability. In that case, the binary gate should remain zero. The output may be useful for review, but it should not be accepted as executable.
+
+[Back to reader](README.md) · [Previous: Governance](02-governance.md) · [Next: Operational Loops](04-operational-loops.md)

--- a/whitepaper/04-operational-loops.md
+++ b/whitepaper/04-operational-loops.md
@@ -1,0 +1,110 @@
+# 04 — Operational Loops
+
+> [!IMPORTANT]
+> A decision is not proven at approval. A decision is proven by what happened after it entered the operation.
+
+## Post Execution Outcome Review
+
+HaleES does not stop grading once an action is approved.
+
+A decision can pass the contract, pass the authority check, pass the policy check, pass the grading layer, receive human approval, and still produce a bad result in the real operation.
+
+| Before action | After action |
+| --- | --- |
+| Recommendation looked correct | Ticket times rose |
+| Labor target was met | Guest complaints increased |
+| Manager approved | Team had to call someone back |
+| Forecast looked safe | Kitchen workload stayed high |
+| Policy passed | Guest experience still suffered |
+
+That outcome must be attached to the original decision.
+
+This creates a consequence loop.
+
+```text
+Recommendation -> Approval -> Action -> Operational Result -> Outcome Review -> Future Contract Update
+```
+
+## Iteration Without Drift
+
+AI systems often improve through iteration, but uncontrolled iteration creates drift.
+
+| Drift risk | HaleES response |
+| --- | --- |
+| Model invents missing context | Contract remains the anchor |
+| Output sounds complete but violates policy | Grading catches constraint failure |
+| Retry loop runs too long | Iteration limit stops it |
+| User pressure changes the task | Contract and authority boundary preserve scope |
+| Unsafe request keeps being rephrased | Escalate, block, or refuse |
+
+The goal is not endless generation. The goal is contract compliant completion or clear refusal and escalation.
+
+## Operational Drift Monitoring
+
+> [!WARNING]
+> If a manager approves every recommendation without review, the system should not assume that all recommendations are good. It should recognize blind approval as a risk pattern.
+
+HaleES must watch for drift in the operation, not only drift in the model.
+
+| Approval drift signal | Possible response |
+| --- | --- |
+| Approvals happen too quickly | Slow down approval flow |
+| Low-quality suggestions are repeatedly accepted | Raise review level |
+| Warnings are ignored | Require reason capture |
+| Exceptions become normal | Trigger calibration check |
+| Nothing is ever rejected | Route certain actions to another leader |
+
+The purpose is not to trick the manager. The purpose is to protect the operation from blind approval.
+
+## Identity and Presence Verification
+
+Role-based authority is not enough in a live hospitality environment.
+
+A manager tablet can be left unlocked. A team member can use someone else's screen. A rushed supervisor can approve something without realizing which account is active.
+
+| Risk level | Identity requirement |
+| --- | --- |
+| Low risk | Normal session identity may be enough |
+| Medium risk | Reconfirm role or active account |
+| High risk | Step-up verification required |
+| Sensitive | PIN, biometric check, or second approval may be required |
+| Restricted | Block or escalate |
+
+The system should verify not only who is logged in, but whether the right person is actually present for the action.
+
+## Emergency Mode
+
+Hospitality operations can break normal patterns quickly.
+
+Power outages, floods, illness outbreaks, violence, payment failures, equipment failures, weather events, and vendor breakdowns can all make normal automation unsafe.
+
+| Emergency mode priority | Meaning |
+| --- | --- |
+| Human control | Reduce automation authority |
+| Safety | Stabilize first |
+| Clear communication | Keep team aligned |
+| Documentation | Preserve the record |
+| Escalation | Route risk upward |
+| Simple checklists | Reduce cognitive load |
+
+Optimization comes later.
+
+## Audit Trails Before Trust
+
+Trust cannot depend only on confidence. In operations, trust requires a record.
+
+| Audit field | Purpose |
+| --- | --- |
+| Initiator | Who started the request |
+| Active role | What authority was used |
+| Contract | What governed the work |
+| Data used | What evidence supported the result |
+| Tool calls | What systems were touched |
+| Grade | Why it passed or failed |
+| Human approval | Who accepted risk |
+| Final action | What actually happened |
+| Outcome | What happened afterward |
+
+Auditability is not paperwork. It is operational memory.
+
+[Back to reader](README.md) · [Previous: Constraints](03-constraints.md) · [Next: Examples](05-examples.md)

--- a/whitepaper/05-examples.md
+++ b/whitepaper/05-examples.md
@@ -1,0 +1,69 @@
+# 05 — Examples
+
+> [!NOTE]
+> These examples show the public pattern. They do not expose production runtime logic.
+
+## Example 1: Call Off Handling
+
+A team member calls off two hours before a dinner rush.
+
+| Basic AI | Enforcement-first HaleES |
+| --- | --- |
+| Suggests asking someone to cover | Checks role, station, timing, eligibility, overtime, approval, and communication rules |
+| Produces a message draft | Determines whether the message is allowed to be sent |
+| Gives one answer | Produces ranked options, risk notes, and escalation triggers |
+| Stops at the recommendation | Records the decision and follows outcome |
+
+> [!IMPORTANT]
+> The system should not blast messages or change the schedule unless authority allows it.
+
+## Example 2: Labor Adjustment
+
+A manager is running high labor during a slow period.
+
+| Basic AI | Enforcement-first HaleES |
+| --- | --- |
+| Recommends cutting two employees | Evaluates sales, forecast, station coverage, skill mix, break rules, role permissions, fairness, minor restrictions, and staffing ratios |
+| Optimizes only for labor | Protects the service model |
+| Treats approval as final | Reviews outcome after action |
+
+A recommendation might cut one cashier at a specific time if sales remain below a threshold, while refusing to cut grill or expo because prep and coverage risk remain high.
+
+This is not just optimization. It is governed decision support.
+
+## Example 3: Vendor Dependent Menu Decision
+
+A restaurant wants to run a menu special based on current inventory.
+
+| Basic AI | Enforcement-first HaleES |
+| --- | --- |
+| Suggests a dish from known ingredients | Verifies inventory freshness, vendor delivery, shorts, substitutions, quality, POS status, kitchen capacity, and offer language |
+| Assumes stale data is acceptable | Lowers confidence or blocks when external ground truth is missing |
+| Produces a creative idea | Determines whether the idea is operationally usable |
+
+If vendor status cannot be verified, the system should lower confidence, require human confirmation, or block the recommendation depending on risk.
+
+## Example 4: Generated Marketing Asset
+
+A restaurant asks HaleES to create a promotional image for a burger special.
+
+| Basic AI | Enforcement-first HaleES |
+| --- | --- |
+| Generates an image | Checks brand rules, offer terms, claims, likeness risk, product accuracy, and approval level |
+| Optimizes for appearance | Grades for brand fit, clarity, accuracy, compliance, and publishing risk |
+| Treats creation as completion | Separates generation from permission to publish |
+
+The image may look good and still fail if it shows the wrong product, implies an unauthorized discount, uses a protected likeness, or violates the brand standard.
+
+## Example Pattern Summary
+
+| Workflow | Enforcement-first check |
+| --- | --- |
+| Scheduling | Availability, role coverage, ratios, approval |
+| Shift swaps | Eligibility, overtime, policy, manager review |
+| Call offs | Coverage risk, contact rules, audit trail |
+| Labor cuts | Demand, safety, station coverage, outcome review |
+| Guest recovery | Privacy, policy, tone, approval |
+| Marketing | Brand, offer accuracy, likeness, publishing permission |
+
+[Back to reader](README.md) · [Previous: Operational Loops](04-operational-loops.md) · [Next: Public Boundary](06-public-boundary.md)

--- a/whitepaper/06-public-boundary.md
+++ b/whitepaper/06-public-boundary.md
@@ -1,0 +1,90 @@
+# 06 — Public Boundary
+
+> [!IMPORTANT]
+> The public specification explains the pattern. The closed runtime remains the machine.
+
+## Open Architecture And Closed Runtime
+
+The public HaleES architecture exists to share the pattern without exposing the production runtime.
+
+## What “Runtime Closed” Means
+
+**Runtime closed** means this public repository explains the HaleES architecture pattern, not the working production engine.
+
+| Public layer | Closed runtime |
+| --- | --- |
+| Concepts | Production orchestration |
+| Schemas | Proprietary grading logic |
+| Contract examples | Business-specific data handling |
+| Validator patterns | Live integrations |
+| Mock loops | Internal execution logic |
+| Reference flows | Deployment infrastructure |
+| Governance primitives | Commercial product workflows |
+| Public-safe constants | Production staffing defaults |
+
+This approach allows public credibility without giving away the operating engine.
+
+The goal is to make the thinking inspectable while keeping the product defensible.
+
+## Liability And Human Override
+
+> [!WARNING]
+> Human approval is not a magic legal firewall. It is one part of a defensible governance chain.
+
+HaleES is designed to support accountable decision making, not remove accountability from the business.
+
+Human override is not a loophole. It is a controlled governance event.
+
+| Boundary | Meaning |
+| --- | --- |
+| Enforcement-first | Reduces the chance unsafe action can execute |
+| Human approval | Preserves accountable human decision authority |
+| Non-overridable policy | Blocks actions even when a high-authority user requests them |
+| Audit trail | Records what was proposed, checked, approved, rejected, and what happened afterward |
+| Outcome review | Feeds consequences back into future contracts |
+
+The stronger firewall is the combination of hard policy boundaries, authority checks, identity verification, external ground truth, grading, audit trails, consequence review, and human approval for high risk actions.
+
+## Design Principles
+
+| Principle | Explanation |
+| --- | --- |
+| Knowledge is not authority | Knowing what should happen does not mean having permission to do it |
+| Generation is not acceptance | An output must be evaluated before it becomes operational |
+| Confidence is not proof | A confident model can still be wrong, incomplete, stale, or unauthorized |
+| Scores are not decisions | A score informs the gate; the gate determines whether action can proceed |
+| Authority does not override core policy | A high ranking user cannot silently bypass constitutional constraints |
+| Automation must be bounded | Every automated action needs scope, limits, and rollback awareness |
+| Humans remain accountable | AI can assist decision making, but operational accountability must remain clear |
+| Memory must be permissioned | Private, organizational, and generalized intelligence must stay separated |
+| Audit trails are infrastructure | If the system cannot explain what happened, it should not be trusted with meaningful action |
+| Outcomes matter | A decision is not proven at approval; it is proven by what happens afterward |
+
+## What HaleES Is Building Toward
+
+HaleES is being built as a hospitality operating layer where intelligence is connected to real operational authority.
+
+The long-term vision includes a governed Sensei intelligence layer, hospitality-specific workflows, contract-based task execution, role-aware permissions, policy enforcement, grading and acceptance gates, human approval controls, external ground truth verification, post-execution outcome analysis, operational memory boundaries, audit trails, creative generation modules, communication modules, marketplace-ready modules, and local-first or API-powered execution where appropriate.
+
+The purpose is not to make hospitality less human.
+
+The purpose is to reduce operational chaos, preserve accountability, and give teams better systems of support.
+
+## Conclusion
+
+> [!IMPORTANT]
+> HaleES is not built around the question “What can AI do?” It is built around the question “What is AI allowed to do, under whose authority, with what evidence, and with what record?”
+
+The future of AI in hospitality will not be won by the system that talks the most.
+
+It will be won by the system that knows when it is allowed to act.
+
+A useful answer is not the same thing as a safe decision. A safe decision is not the same thing as permission to act.
+
+That gap is where enforcement-first AI operations begins.
+
+The runtime remains closed.
+
+The architecture pattern is public.
+
+[Back to reader](README.md) · [Previous: Examples](05-examples.md)

--- a/whitepaper/README.md
+++ b/whitepaper/README.md
@@ -1,0 +1,104 @@
+<div align="center">
+
+# HaleES Whitepaper Reader
+
+## Enforcement First AI Operations for Hospitality
+
+**A designed public reader for the HaleES enforcement-first architecture paper.**
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Reader-Designed%20Public%20Paper-gold.svg?style=flat" alt="Designed Public Paper">
+  <img src="https://img.shields.io/badge/Runtime-Closed-black.svg?style=flat" alt="Runtime: Closed">
+  <img src="https://img.shields.io/badge/Pattern-Enforcement%20First-gold.svg?style=flat" alt="Pattern: Enforcement First">
+  <img src="https://img.shields.io/badge/Hospitality-Governance-gold.svg?style=flat" alt="Hospitality Governance">
+</p>
+
+</div>
+
+> [!IMPORTANT]
+> **Core claim:** A useful AI answer is not the same thing as a safe decision. A safe decision is not the same thing as permission to act.
+
+> [!NOTE]
+> This folder is the visually designed reader version of the whitepaper. The single-file archival version remains at [`FULL_WHITEPAPER.md`](../FULL_WHITEPAPER.md).
+
+---
+
+## What “Runtime Closed” Means
+
+> [!IMPORTANT]
+> **Runtime closed** means this public repository explains the HaleES architecture pattern, not the working production engine.
+
+| Public paper can show | Closed runtime does not expose |
+| --- | --- |
+| Architecture concepts | Production orchestration code |
+| Governance flows | Private grader implementation |
+| Contract examples | Real model/tool routing |
+| Public diagrams | Live integrations |
+| Schemas and mock loops | Customer data handling |
+| Public-safe constants | Deployment and infrastructure internals |
+| Design principles | Commercial execution workflows |
+
+The pattern is public. The operating engine remains closed.
+
+---
+
+## Reader Map
+
+| Part | File | Focus |
+| --- | --- | --- |
+| 01 | [Foundation](01-foundation.md) | Problem, central claim, hospitality context, governed execution |
+| 02 | [Governance](02-governance.md) | Authority, policy, contracts, and permission boundaries |
+| 03 | [Constraints](03-constraints.md) | Staffing ratios, identity constants, ground truth, grading |
+| 04 | [Operational Loops](04-operational-loops.md) | Outcome review, iteration, drift, identity, emergency mode, audit |
+| 05 | [Examples](05-examples.md) | Call-off handling, labor adjustment, vendor decisions, creative governance |
+| 06 | [Public Boundary](06-public-boundary.md) | Public architecture vs closed runtime, design principles, conclusion |
+
+---
+
+## Executive Signal
+
+| HaleES separates | Why it matters |
+| --- | --- |
+| Knowledge from authority | Knowing is not permission |
+| Generation from acceptance | Output does not equal trust |
+| Confidence from proof | A confident system can still be wrong |
+| Human approval from override | Review is not a loophole |
+| Public architecture from closed runtime | The pattern can be inspected without exposing the engine |
+
+---
+
+## Enforcement First Flow
+
+```text
+Request -> Contract -> Authority Check -> Policy Check -> Ground Truth Verification -> Execution Within Scope -> Grading -> Acceptance Gate -> Human Approval If Required -> Audit Trail -> Outcome Review -> Future Contract Feedback
+```
+
+<details>
+<summary><strong>View governed execution diagram</strong></summary>
+
+```mermaid
+flowchart TD
+    A[Request] --> B[Contract]
+    B --> C[Authority Check]
+    C --> D[Policy Check]
+    D --> E[Ground Truth Verification]
+    E --> F[Execution Within Scope]
+    F --> G[Grading]
+    G --> H{Acceptance Gate}
+    H -->|Pass| I[Human Approval If Required]
+    H -->|Fail| J[Revise Block Or Escalate]
+    I --> K[Audit Trail]
+    K --> L[Outcome Review]
+    L --> M[Future Contract Feedback]
+```
+
+</details>
+
+---
+
+## How To Read This Paper
+
+Start with **Foundation** if you want the thesis. Start with **Governance** if you care about authority. Start with **Constraints** if you want the “identity becomes constraint” layer. Start with **Examples** if you want to see the pattern in restaurant operations.
+
+> [!TIP]
+> The reader version is designed for GitHub mobile and public scanning. The full archival paper remains available as one file for citation and preservation.


### PR DESCRIPTION
## Summary

Adds a new designed whitepaper reader package under `whitepaper/` so the HaleES whitepaper renders better on GitHub and mobile.

## What changed

- Adds `whitepaper/README.md` as the visual reader entry point.
- Adds six smaller reader sections:
  - `whitepaper/01-foundation.md`
  - `whitepaper/02-governance.md`
  - `whitepaper/03-constraints.md`
  - `whitepaper/04-operational-loops.md`
  - `whitepaper/05-examples.md`
  - `whitepaper/06-public-boundary.md`
- Updates the main `README.md` front-door table to point to the designed whitepaper reader.
- Keeps `FULL_WHITEPAPER.md` as the full single-file archival version.

## Why

The single full whitepaper file is useful for preservation, but it is heavy for GitHub mobile and makes the paper feel like a long wall of text. This PR creates a cleaner public reader with section-by-section visual structure, callouts, tables, and smaller pages.

## Runtime closed explanation

The designed reader explains that `Runtime: Closed` means the public repo shows the architecture pattern, not the working production engine. It does not expose production orchestration, private grading logic, live integrations, model/tool routing internals, customer data handling, deployment infrastructure, commercial runtime workflows, or production staffing defaults.

## Public vs closed boundary

Public:

- Concepts
- Governance flows
- Contract examples
- Public diagrams
- Public-safe constants
- Design principles

Closed:

- Production orchestration
- Proprietary grader logic
- Live integrations
- Private data handling
- Model/tool routing implementation
- Deployment infrastructure
- Commercial runtime logic
- Production staffing defaults

## Acceptance status

Draft PR opened for review before merge.